### PR TITLE
ci: fix automated baseline PR targeting and branch collision

### DIFF
--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -89,7 +89,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: chore/update-baselines
+          branch: chore/update-baselines-${{ github.sha }}
+          delete-branch: true
+          base: production
           title: "chore: update performance baselines"
           body: |
             ### 🚀 Automated Baseline Update


### PR DESCRIPTION
Explicitly set the base branch to production and use a unique branch name derived from the commit SHA. This ensures that the automated PR is correctly visible and doesn't collide with existing 'chore/update-baselines' branches.