### PR TITLE
fix(rag): relax quality gate for non-markdown structured documents

### DIFF
--- a/src/candlekeep/mcp/server.py
+++ b/src/candlekeep/mcp/server.py
@@ -307,6 +307,26 @@ threading.Thread(target=_background_init, daemon=True).start()
 
 # --- Quality gate for ingestion ---
 
+def _find_body_start(lines: list[str]) -> int:
+    """Return the line index where the document body begins (after frontmatter)."""
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return i + 1
+    return 0
+
+
+def _count_setext_headers(lines: list[str], start: int) -> int:
+    """Count setext-style headers (underline with === or ---) starting from a line index."""
+    count = 0
+    for i in range(max(start, 1), len(lines)):
+        line = lines[i].strip()
+        if line and len(line) >= 3 and all(c in '=-' for c in line) and lines[i - 1].strip():
+            count += 1
+    return count
+
+
 def check_document_quality(path: Path) -> list[str]:
     """Check document quality for RAG suitability. Returns list of issues (empty = OK)."""
     content = path.read_text(encoding="utf-8", errors="replace")
@@ -314,15 +334,20 @@ def check_document_quality(path: Path) -> list[str]:
     words = len(content.split())
     issues = []
 
-    if not content.startswith("---"):
+    has_frontmatter = content.startswith("---")
+    if not has_frontmatter:
         issues.append("Missing YAML frontmatter (title, description, keywords, category, tags)")
-    if sum(1 for l in lines if l.startswith("#")) < 2:
-        issues.append("Insufficient structure (fewer than 2 markdown headers)")
-    if words < 100:
-        issues.append("Too short (< 100 words) — consider combining with related content")
+
+    body_start = _find_body_start(lines)
+    md_headers = sum(1 for l in lines[body_start:] if l.startswith("#"))
+    setext_headers = _count_setext_headers(lines, body_start)
+    if (md_headers + setext_headers) < 2 and not has_frontmatter:
+        issues.append("Insufficient structure (fewer than 2 headers)")
+    if words < 50:
+        issues.append("Too short (< 50 words) — consider combining with related content")
     if words > 10000:
         issues.append("Too long (> 10k words) — consider splitting into focused documents")
-    if content.count("```") % 2 != 0:
+    if sum(1 for l in lines if l.strip().startswith("```")) % 2 != 0:
         issues.append("Unclosed code block (mismatched ``` markers)")
 
     return issues
@@ -611,8 +636,8 @@ ingest() will reject documents that fail these checks:
 
 - **YAML frontmatter required** — must start with `---` and include:
   title, description, keywords, category, tags
-- **At least 2 markdown headers** (## or ###)
-- **Between 100 and 10,000 words**
+- **At least 2 headers** (ATX `#` or setext `===`/`---` style) — or YAML frontmatter as proof of curation
+- **Between 50 and 10,000 words**
 - **No unclosed code blocks** (matched ``` pairs)
 
 Frontmatter template:
@@ -660,8 +685,8 @@ def ingest(path: str, ctx: Context = CurrentContext()) -> str:
 
     Validates document quality before ingestion. Documents must have:
     - YAML frontmatter (title, description, keywords)
-    - At least 2 markdown headers
-    - Between 100 and 10,000 words
+    - At least 2 headers (ATX or setext) — or frontmatter as proof of curation
+    - Between 50 and 10,000 words
 
     Supports: txt, md, pdf, rst, json, yaml files.
     """

--- a/src/candlekeep/rag/processor.py
+++ b/src/candlekeep/rag/processor.py
@@ -115,19 +115,22 @@ class DocumentProcessor:
             raise RuntimeError(f"Failed to extract PDF: {e}")
 
     HEADER_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+    SETEXT_PATTERN = re.compile(r"^(.+)\n([=\-]{3,})$", re.MULTILINE)
 
     def _chunk_text(self, text: str) -> list[str]:
         if not text.strip():
             return []
 
         size, overlap = self.settings.chunk_size, self.settings.chunk_overlap
-        headers = list(self.HEADER_PATTERN.finditer(text))
+        atx_headers = [(m.start(), m.group()) for m in self.HEADER_PATTERN.finditer(text)]
+        setext_headers = [(m.start(), m.group()) for m in self.SETEXT_PATTERN.finditer(text)]
+        headers = sorted(atx_headers + setext_headers, key=lambda x: x[0])
 
         if not headers:
             return self._fixed_chunk(text, size, overlap)
 
         chunks = []
-        positions = [m.start() for m in headers]
+        positions = [pos for pos, _ in headers]
 
         if positions[0] > 0:
             preamble = text[:positions[0]].strip()

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -56,8 +56,14 @@ keywords: ["test"]
 ---
 
 This document has frontmatter but no markdown headers at all. It is just
-a flat block of text with no structure. The quality gate should reject it
-because it needs at least two headers for proper chunking to work well.
+a flat block of text with no structure. Because it has frontmatter the
+quality gate trusts it as curated content and allows it through.
+"""
+
+NO_HEADERS_NO_FRONTMATTER = """This document has no YAML frontmatter and no markdown headers at all.
+It is just a flat block of text with no structure. The quality gate should
+reject it because it has neither frontmatter nor headers to prove curation.
+We need enough words here to avoid the too-short check triggering as well.
 """
 
 TOO_SHORT = """---
@@ -70,7 +76,7 @@ keywords: ["test"]
 
 ## Very Short
 
-Too few words here.
+Too few words.
 """
 
 UNCLOSED_CODE = """---
@@ -108,9 +114,16 @@ class TestQualityGate:
         assert any("frontmatter" in i.lower() for i in issues)
 
     def test_missing_headers_rejected(self):
-        path = _write_temp(NO_HEADERS)
+        """No frontmatter + no headers = rejected."""
+        path = _write_temp(NO_HEADERS_NO_FRONTMATTER)
         issues = check_document_quality(path)
         assert any("header" in i.lower() or "structure" in i.lower() for i in issues)
+
+    def test_frontmatter_no_headers_passes(self):
+        """Frontmatter acts as proof of curation - headers not required."""
+        path = _write_temp(NO_HEADERS)
+        issues = check_document_quality(path)
+        assert not any("header" in i.lower() or "structure" in i.lower() for i in issues)
 
     def test_too_short_rejected(self):
         path = _write_temp(TOO_SHORT)


### PR DESCRIPTION
The quality gate in `check_document_quality()` was too strict for documents that use valid but non-markdown formatting conventions, causing silent rejections when ingesting well-structured technical documentation.

**Four issues addressed:**

1. **Recognise underline-style headers (setext headings)** - Markdown supports ATX (`#` prefix) and setext (`===` / `---`) heading styles. Only ATX was counted.

2. **Skip header check for documents with YAML frontmatter** - Frontmatter proves intentional curation. Short reference docs (glossaries, config guides) often use numbered lists instead of headers.

3. **Lower minimum word count from 100 to 50** - Focused reference documents (debugging guides, build instructions) are intentionally concise. 94 words of clear content shouldn't be rejected.

4. **Fix false positive on inline code fence mentions** - The check counted all triple-backtick occurrences including inline prose mentions. Now only counts line-starting fences, which is how actual code blocks work in markdown.