### PR TITLE
ci: use artifact pattern for PR comments to support fork contributions

### DIFF
--- a/.github/workflows/post-comment.yml
+++ b/.github/workflows/post-comment.yml
@@ -1,0 +1,40 @@
+name: Post PR Comment
+
+on:
+  workflow_run:
+    workflows: ["Comprehensive Tests"]
+    types:
+      - completed
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    # Run only if the triggering workflow was a PR and wasn't skipped
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR Number
+        id: pr_number
+        run: |
+          if [ -f pr_number.txt ]; then
+            echo "number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
+          else
+            echo "No pr_number.txt found"
+            exit 1
+          fi
+
+      - name: Post Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: test-results
+          path: pr_comment.md
+          number: ${{ steps.pr_number.outputs.number }}
+          recreate: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
       - '**.md'
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:
@@ -129,11 +128,16 @@ jobs:
           echo "" >> pr_comment.md
           echo "*Updated at: $(date -u)*" >> pr_comment.md
 
-      - name: Post PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Save PR Number
         if: github.event_name == 'pull_request' && always()
+        run: |
+          echo ${{ github.event.number }} > pr_number.txt
+
+      - name: Upload PR Comment Artifact
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/upload-artifact@v4
         with:
-          header: test-results
-          path: pr_comment.md
-          recreate: true
-          only_if_last_comment_is_not_from_bot: true
+          name: pr_comment
+          path: |
+            pr_comment.md
+            pr_number.txt


### PR DESCRIPTION
The default GITHUB_TOKEN has restricted read-only permissions for pull requests originating from forks to prevent potential security exploits. This caused automated test reporting to fail when processing external contributions. By separating the test execution from the comment posting using a two-stage artifact hand-off, we can safely report results from a privileged context without exposing the main test environment to elevated permissions.