### PR TITLE
ci: automate nightly development releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,51 @@
+name: Nightly Dev Release
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Midnight UTC
+  workflow_dispatch: # Allow manual trigger for testing
+
+jobs:
+  nightly:
+    name: Build & Push Nightly
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev # Always build from the dev branch
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Nightly Metadata
+        id: meta
+        run: |
+          DATE=$(date +'%Y%m%d')
+          echo "date=$DATE" >> $GITHUB_OUTPUT
+          echo "image=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:nightly
+            ${{ steps.meta.outputs.image }}:nightly-${{ steps.meta.outputs.date }}
+          labels: |
+            org.opencontainers.image.title=Candlekeep (Nightly)
+            org.opencontainers.image.description=Nightly development build of the Candlekeep RAG server.
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR adds a new 'Nightly Dev Release' workflow that builds and pushes the latest 'dev' branch to GHCR every night at midnight UTC. This ensures we always have a fresh 'nightly' Docker image available for development and testing environments.